### PR TITLE
Update compatibility, joystick buttons, and gameplay improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,3 +8,4 @@
 - Refactored Breakout to support multiple simultaneous balls and added new Sticky, Laser, Break, Expand, Slow, and Triple power-ups that randomly drop from destroyed bricks, fall toward the paddle, and apply temporary effects (press A/B to release stuck balls or fire lasers).
 - Dim and center the Game Over / You Win overlays in Breakout for improved readability.
 - Tetris lateral movement now repeats while holding left/right, and the Game Over screen (and Snake’s) is centered along with the score.
+- Selecting games now shows a centered title card on the matrix so the active choice is visible before it starts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# FPP Arcade Changelog
+
+## Unreleased
+- Added dedicated `A Button` and `B Button` controller bindings in the command list and web UI.
+- Updated joystick defaults to map common gamepad buttons 0/1 to the new A/B bindings.
+- In Tetris, `A Button` (or `Up`) now rotates clockwise while `B Button` rotates counter-clockwise.
+- Breakout now uses gap-aware brick collisions that prevent the ball from slipping between bricks.
+- Refactored Breakout to support multiple simultaneous balls and added new Sticky, Laser, Break, Expand, Slow, and Triple power-ups that randomly drop from destroyed bricks, fall toward the paddle, and apply temporary effects (press A/B to release stuck balls or fire lasers).
+- Dim and center the Game Over / You Win overlays in Breakout for improved readability.
+- Tetris lateral movement now repeats while holding left/right, and the Game Over screen (and Snake’s) is centered along with the score.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 # FPP Arcade Changelog
 
-## Unreleased
 - Added dedicated `A Button` and `B Button` controller bindings in the command list and web UI.
 - Updated joystick defaults to map common gamepad buttons 0/1 to the new A/B bindings.
 - In Tetris, `A Button` (or `Up`) now rotates clockwise while `B Button` rotates counter-clockwise.
 - Breakout now uses gap-aware brick collisions that prevent the ball from slipping between bricks.
 - Refactored Breakout to support multiple simultaneous balls and added new Sticky, Laser, Break, Expand, Slow, and Triple power-ups that randomly drop from destroyed bricks, fall toward the paddle, and apply temporary effects (press A/B to release stuck balls or fire lasers).
 - Dim and center the Game Over / You Win overlays in Breakout for improved readability.
+- Breakout sticky paddle shots now launch toward the side they were caught on, and end-of-game dimming applies to all sprites including power-up pills.
+- Breakout now advances through multiple themed layouts with multi-hit and indestructible bricks instead of stopping after one board.
+- Standardized timing across Pong, Snake, Tetris, and Breakout using real elapsed milliseconds to remove jittery speed changes.
 - Tetris lateral movement now repeats while holding left/right, and the Game Over screen (and Snake’s) is centered along with the score.
 - Selecting games now shows a centered title card on the matrix so the active choice is visible before it starts.

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ all: libfpp-arcade.$(SHLIB_EXT)
 debug: all
 
 CFLAGS+=-I.
-OBJECTS_fpp_arcade_so += src/FPPArcade.o src/FPPTetris.o src/FPPPong.o src/FPPSnake.o src/FPPBreakout.o
+OBJECTS_fpp_arcade_so += src/FPPArcade.o src/FPPTetris.o src/FPPPong.o src/FPPSnake.o src/FPPBreakout.o src/FPPFrogger.o
 LIBS_fpp_arcade_so += -L$(SRCDIR) -lfpp -ljsoncpp -lhttpserver -lSDL2
 CXXFLAGS_src/FPPArcade.o += -I$(SRCDIR)
 

--- a/joysticks.php
+++ b/joysticks.php
@@ -80,7 +80,8 @@ function SaveJoystickInputs() {
     
 }
 var GPMAPPING = {
-    "1": "Fire",
+    "0": "B Button",
+    "1": "A Button",
     "8": "Select",
     "9": "Start",
     "11": "Up",
@@ -113,7 +114,7 @@ function SetDefaultsForController() {
     js["multisyncCommand"] = false,
     js["multisyncHosts"] = "",
     js["args"] = Array();
-    js["args"].push("Fire - Pressed");
+    js["args"].push("A Button - Pressed");
     js["args"].push(target);
 
     var jsa = Array();

--- a/plugin_setup.php
+++ b/plugin_setup.php
@@ -58,6 +58,14 @@ function GetBreakoutOptions() {
     var html = "";
     return html;
 }
+function GetFroggerOptions() {
+    var html  = "Pixel Scaling: <input type='number' value='1' min='1' max='20' class='option1' data-optionname='Pixel Scaling'/>&nbsp;";
+    html     += "Lanes: <input type='number' value='5' min='1' max='20' class='option2' data-optionname='Lanes'/>&nbsp;";
+    html     += "River Speed: <input type='number' value='1' min='1' max='10' class='option4' data-optionname='River Speed'/>&nbsp;";
+    html     += "Road Speed: <input type='number' value='1' min='1' max='10' class='option5' data-optionname='Road Speed'/>";
+    html     += "Speed Variability (%): <input type='number' value='20' min='0' max='100' class='option6' data-optionname='Speed Variability'/>";
+    return html;
+}
 
 function GameChanged(sel) {
     var val = $(sel).val();
@@ -70,6 +78,8 @@ function GameChanged(sel) {
         html = GetSnakeOptions();
     } else if (val == "Breakout") {
         html = GetBreakoutOptions();
+    } else if (val == "Frogger") {
+        html = GetFroggerOptions();
     }
     $(sel).parent().parent().find(".GameOptions").html(html);
 }
@@ -88,6 +98,7 @@ function AddArcade() {
     html += "<option value='Pong'>Pong</option>";
     html += "<option value='Snake'>Snake</option>";
     html += "<option value='Breakout'>Breakout</option>";
+    html += "<option value='Frogger'>Frogger</option>";
     html += "</select></td>";
     html += "<td><select class='model'>";
     html += modelOptions;

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -53,7 +53,8 @@ static std::vector<std::string> BUTTONS({
     "Up/Right - Pressed", "Up/Right - Released",
     "Down/Left - Pressed", "Down/Left - Released",
     "Down/Right - Pressed", "Down/Right - Released",
-    "Fire - Pressed", "Fire - Released",
+    "A Button - Pressed", "A Button - Released",
+    "B Button - Pressed", "B Button - Released",
     "Select - Pressed", "Select - Released",
     "Start - Pressed", "Start - Released",
 });
@@ -286,6 +287,19 @@ void FPPArcadeGameEffect::outputString(const std::string &s, int x, int y, int r
         outputLetter(x, y, ch, r, g, b, scl);
         x += 4;
     }
+}
+
+int FPPArcadeGameEffect::centerTextX(const std::string &s, int scl) {
+    if (scl == -1) {
+        scl = scale == 0 ? 1 : scale;
+    }
+    int gridWidth = std::max(1, model->getWidth() / scl);
+    int textWidth = static_cast<int>(s.size()) * 4;
+    int x = (gridWidth - textWidth) / 2;
+    if (x < 0) {
+        x = 0;
+    }
+    return x;
 }
 
 class FPPArcadePlugin : public FPPPlugin , public httpserver::http_resource {

--- a/src/FPPArcade.h
+++ b/src/FPPArcade.h
@@ -39,6 +39,7 @@ public:
 
     void outputString(const std::string &s, int x, int y, int r = 255, int g = 255, int b = 255, int scl = -1);
     void outputLetter(int x, int y, char letter, int r = 255, int g = 255, int b = 255, int scl = -1);
+    int centerTextX(const std::string &s, int scl = -1);
     void outputPixel(int x, int y, int r, int g, int b, int scl = -1);
     
     int scale;

--- a/src/FPPArcade.h
+++ b/src/FPPArcade.h
@@ -2,6 +2,7 @@
 #define __FPPARCADE__
 
 #include <string>
+#include <chrono>
 
 #include "overlays/PixelOverlayEffects.h"
 
@@ -42,10 +43,15 @@ public:
     void outputLetter(int x, int y, char letter, int r = 255, int g = 255, int b = 255, int scl = -1);
     int centerTextX(const std::string &s, int scl = -1);
     void outputPixel(int x, int y, int r, int g, int b, int scl = -1);
+    double consumeElapsedMs(double fallbackMs, double maxClampMs = 250.0);
+    void resetFrameTimer();
     
     int scale;
     int offsetX;
     int offsetY;
+private:
+    std::chrono::steady_clock::time_point lastFrameTime;
+    bool firstFrame = true;
 };
 
 #endif

--- a/src/FPPArcade.h
+++ b/src/FPPArcade.h
@@ -21,6 +21,7 @@ public:
 
     int getIdx() const { return idx; };
     void setIdx(int i) { idx = i; }
+    const std::string &getModelName() const { return modelName; }
 protected:
     std::string findOption(const std::string &s, const std::string &def = "");
     

--- a/src/FPPBreakout.cpp
+++ b/src/FPPBreakout.cpp
@@ -1,8 +1,13 @@
 #include <fpp-pch.h>
 
 #include "FPPBreakout.h"
+#include <algorithm>
 #include <array>
+#include <cmath>
+#include <cstdlib>
+#include <list>
 #include <random>
+#include <vector>
 
 #include "overlays/PixelOverlay.h"
 #include "overlays/PixelOverlayModel.h"
@@ -26,16 +31,21 @@ public:
     float x = 0;
     float width = 0;
     float height = 0;
+    int row = -1;
+    int col = -1;
     
     float left() const { return x; }
     float top() const { return y; }
     float right() const { return x + width - 0.1; }
     float bottom() const { return y + height - 0.1; }
 
-    void draw(PixelOverlayModel *m) {
+    void draw(PixelOverlayModel *m, float brightness = 1.0f) const {
+        int rr = std::clamp(static_cast<int>(r * brightness), 0, 255);
+        int gg = std::clamp(static_cast<int>(g * brightness), 0, 255);
+        int bb = std::clamp(static_cast<int>(b * brightness), 0, 255);
         for (int xp = 0; xp < width; xp++) {
             for (int yp = 0; yp < height; yp++) {
-                m->setOverlayPixelValue(xp + x, yp + y, r, g, b);
+                m->setOverlayPixelValue(xp + x, yp + y, rr, gg, bb);
             }
         }
     }
@@ -46,13 +56,84 @@ public:
     }
 };
 
-class Ball : public Block {
+struct Ball {
+    float x = 0;
+    float y = 0;
+    float width = 0;
+    float height = 0;
+    float directionX = 0.25f;
+    float directionY = 0.75f;
+    float speed = 1.0f;
+    bool stuck = false;
+    float stickOffset = 0; // relative to paddle center
+
+    float left() const { return x; }
+    float right() const { return x + width - 0.1f; }
+    float top() const { return y; }
+    float bottom() const { return y + height - 0.1f; }
+
+    void move() {
+        if (stuck) {
+            return;
+        }
+        x += directionX * speed;
+        y += directionY * speed;
+    }
+};
+
+struct Laser {
+    float x = 0;
+    float y = 0;
+    float speed = 4.0f;
+};
+
+class PowerUp {
 public:
-    
-    
-    float directionX = 0.25;
-    float directionY = 0.75;
-    float speed = 1;
+    enum class Type { Expand, Slow, Break, Sticky, Laser, Triple };
+
+    PowerUp(Type t, float px, float py, float size, float fall)
+        : type(t), x(px), y(py), width(size), height(size), fallSpeed(fall) {
+        switch (type) {
+            case Type::Expand:
+                r = 0; g = 200; b = 255;
+                break;
+            case Type::Slow:
+                r = 255; g = 215; b = 0;
+                break;
+            case Type::Break:
+                r = 255; g = 0; b = 255;
+                break;
+            case Type::Sticky:
+                r = 0; g = 255; b = 120;
+                break;
+            case Type::Laser:
+                r = 220; g = 0; b = 0;
+                break;
+            case Type::Triple:
+                r = 255; g = 255; b = 255;
+                break;
+        }
+    }
+
+    void draw(PixelOverlayModel *m) const {
+        int ix = static_cast<int>(std::round(x));
+        int iy = static_cast<int>(std::round(y));
+        for (int xp = 0; xp < width; xp++) {
+            for (int yp = 0; yp < height; yp++) {
+                m->setOverlayPixelValue(ix + xp, iy + yp, r, g, b);
+            }
+        }
+    }
+
+    Type type;
+    float x;
+    float y;
+    float width;
+    float height;
+    float fallSpeed;
+    int r = 255;
+    int g = 255;
+    int b = 255;
 };
 
 
@@ -78,6 +159,7 @@ public:
             paddle.height = 1;
         }
         paddle.y = h - 1 - paddle.height;
+        basePaddleWidth = paddle.width;
         
         
         int blockW = w / 20;
@@ -92,25 +174,42 @@ public:
         int numBlockW = w / (blockW+1);
         int curY = blockH*2;
         int xOff = (w - numBlockW * (blockW+1)) / 2;
-        for (int y = 0; y < COLORS.size(); y++, curY += (blockH+1) ) {
-            for (int x = 0; x < numBlockW; x++) {
+        brickCols = numBlockW;
+        brickRows = COLORS.size();
+        brickWidth = blockW;
+        brickHeight = blockH;
+        columnStarts.resize(brickCols);
+        for (int x = 0; x < numBlockW; x++) {
+            columnStarts[x] = xOff + x * (blockW + 1);
+        }
+        rowStarts.resize(brickRows);
+        bricksAlive.assign(brickRows, std::vector<bool>(brickCols, false));
+        for (int y = 0; y < brickRows; y++, curY += (blockH+1) ) {
+            rowStarts[y] = curY;
+            for (int x = 0; x < brickCols; x++) {
                 Block b;
-                b.x = xOff + x * (blockW+1);
+                b.x = columnStarts[x];
                 b.height = blockH;
                 b.width = blockW;
                 b.y = curY;
                 b.r = (COLORS[y] >> 16) & 0xFF;
                 b.g = (COLORS[y] >> 8) & 0xFF;
                 b.b = COLORS[y] & 0xFF;
+                b.row = y;
+                b.col = x;
                 blocks.push_back(b);
+                bricksAlive[y][x] = true;
             }
         }
         
-        ball.x = w / 2;
-        ball.y = h * 2 / 3;
-        ball.height = paddle.height;
-        ball.width = paddle.height;
-        ball.speed *= (float)paddle.height;
+        Ball b;
+        b.x = w / 2;
+        b.y = h * 2 / 3;
+        b.height = paddle.height;
+        b.width = paddle.height;
+        b.speed *= (float)paddle.height;
+        baseBallSpeed = b.speed;
+        balls.push_back(b);
         CopyToModel();
     }
     ~BreakoutEffect() {
@@ -121,50 +220,408 @@ public:
         return NAME;
     }
 
-    void moveBall() {
-        ball.x += ball.directionX * ball.speed;
-        ball.y += ball.directionY * ball.speed;
-        
-        if (ball.y < 0) {
-            ball.directionY = std::fabs(ball.directionY);
-            ball.y = 0;
-        }
-        if (ball.x < 0) {
-            ball.directionX = std::fabs(ball.directionX);
-            ball.x = 0;
-        }
-        if (ball.x >= model->getWidth()) {
-            ball.directionX = -std::fabs(ball.directionX);
-            ball.x = model->getWidth() - 1;
-        }
-        auto it = blocks.begin();
-        while (it != blocks.end()) {
-            if (it->intersects(ball)) {
-                if (ball.right() <= (it->left() + 0.35)) {
-                    ball.directionX = std::fabs(ball.directionX);
-                } else if (ball.left() >= (it->right() - 0.35)) {
-                    ball.directionX = std::fabs(ball.directionX);
-                } else if (ball.bottom() <= (it->top()+0.5)) {
-                    ball.directionY = -std::fabs(ball.directionY);
-                } else {
-                    ball.directionY = std::fabs(ball.directionY);
+    void moveBalls() {
+        constexpr float gapPadding = 0.4f;
+        auto ballIt = balls.begin();
+        while (ballIt != balls.end()) {
+            Ball &ball = *ballIt;
+            if (ball.stuck) {
+                float paddleCenter = paddle.x + paddle.width / 2.0f;
+                float newCenter = paddleCenter + ball.stickOffset;
+                ball.x = newCenter - ball.width / 2.0f;
+                ball.y = paddle.y - ball.height;
+                ++ballIt;
+                continue;
+            } else {
+                ball.move();
+            }
+            if (ball.y < 0) {
+                ball.directionY = std::fabs(ball.directionY);
+                ball.y = 0;
+            }
+            if (ball.x < 0) {
+                ball.directionX = std::fabs(ball.directionX);
+                ball.x = 0;
+            }
+            if (ball.x >= model->getWidth()) {
+                ball.directionX = -std::fabs(ball.directionX);
+                ball.x = model->getWidth() - 1;
+            }
+
+            bool brickHit = false;
+            auto it = blocks.begin();
+            while (it != blocks.end()) {
+                float bLeft = it->left() - gapPadding;
+                float bRight = it->right() + gapPadding;
+                float bTop = it->top() - gapPadding;
+                float bBottom = it->bottom() + gapPadding;
+
+                bool overlaps = (ball.right() >= bLeft && ball.left() <= bRight &&
+                                  ball.bottom() >= bTop && ball.top() <= bBottom);
+                if (!overlaps) {
+                    ++it;
+                    continue;
+                }
+                if (!powerBallActive) {
+                    float overlapLeft = ball.right() - bLeft;
+                    float overlapRight = bRight - ball.left();
+                    float overlapTop = ball.bottom() - bTop;
+                    float overlapBottom = bBottom - ball.top();
+
+                    float minHoriz = std::min(overlapLeft, overlapRight);
+                    float minVert = std::min(overlapTop, overlapBottom);
+                    if (minHoriz < minVert) {
+                        if (overlapLeft < overlapRight) {
+                            ball.directionX = -std::fabs(ball.directionX);
+                            ball.x = bLeft - ball.width;
+                        } else {
+                            ball.directionX = std::fabs(ball.directionX);
+                            ball.x = bRight;
+                        }
+                    } else {
+                        if (overlapTop < overlapBottom) {
+                            ball.directionY = -std::fabs(ball.directionY);
+                            ball.y = bTop - ball.height;
+                        } else {
+                            ball.directionY = std::fabs(ball.directionY);
+                            ball.y = bBottom;
+                        }
+                    }
                 }
 
-                blocks.erase(it);
-                return;
+                maybeSpawnPowerUp(*it);
+                markBrickGone(it->row, it->col);
+                it = blocks.erase(it);
+                brickHit = true;
+                break;
             }
-            it++;
+
+            if (!brickHit) {
+                handleGapCollision(ball);
+            }
+
+            if (ball.y >= model->getHeight()) {
+                ballIt = balls.erase(ballIt);
+                continue;
+            }
+
+            ++ballIt;
         }
     }
 
-    void CopyToModel() {
+    void handleGapCollision(Ball &ball) {
+        if (brickRows == 0 || brickCols <= 1) {
+            return;
+        }
+        for (int row = 0; row < brickRows; ++row) {
+            float topY = rowStarts[row];
+            float bottomY = topY + brickHeight;
+            if (ball.bottom() < topY || ball.top() > bottomY) {
+                continue;
+            }
+            for (int col = 0; col < brickCols - 1; ++col) {
+                if (!(bricksAlive[row][col] && bricksAlive[row][col + 1])) {
+                    continue;
+                }
+                float gapStart = columnStarts[col] + brickWidth;
+                float gapEnd = columnStarts[col + 1];
+                if (ball.right() <= gapStart || ball.left() >= gapEnd) {
+                    continue;
+                }
+                if (ball.directionY > 0) {
+                    ball.directionY = -std::fabs(ball.directionY);
+                    ball.y = gapStart - ball.height;
+                } else {
+                    ball.directionY = std::fabs(ball.directionY);
+                    ball.y = gapEnd;
+                }
+                return;
+            }
+        }
+    }
+
+    void markBrickGone(int row, int col) {
+        if (row >= 0 && row < (int)bricksAlive.size() &&
+            col >= 0 && col < (int)bricksAlive[row].size()) {
+            bricksAlive[row][col] = false;
+        }
+    }
+
+    void maybeSpawnPowerUp(const Block &from) {
+        PowerUp::Type selected;
+        if (!pickPowerUp(selected)) {
+            return;
+        }
+        float size = std::max(2.0f, paddle.height * 1.5f);
+        float px = from.x + (from.width / 2.0f) - (size / 2.0f);
+        float py = from.y + from.height; // start just below the brick
+        float fall = std::max(0.25f, static_cast<float>(model->getHeight()) / 160.0f);
+        powerUps.emplace_back(selected, px, py, size, fall);
+    }
+
+    bool pickPowerUp(PowerUp::Type &type) {
+        // Approximate Arkanoid drop frequencies for E (Expand), B (Break), S (Slow)
+        struct Entry { PowerUp::Type type; int weight; };
+        static const std::array<Entry, 6> table = {{{PowerUp::Type::Break, 12},
+                                                   {PowerUp::Type::Expand, 12},
+                                                   {PowerUp::Type::Slow, 5},
+                                                   {PowerUp::Type::Sticky, 5},
+                                                   {PowerUp::Type::Laser, 5},
+                                                   {PowerUp::Type::Triple, 4}}};
+        // Only allow a drop roughly 12% of the time.
+        if ((std::rand() % 100) >= 12) {
+            return false;
+        }
+        int totalWeight = 0;
+        for (const auto &entry : table) {
+            totalWeight += entry.weight;
+        }
+        int roll = std::rand() % totalWeight;
+        int accum = 0;
+        for (const auto &entry : table) {
+            accum += entry.weight;
+            if (roll < accum) {
+                type = entry.type;
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void CopyToModel(float brightness = 1.0f) {
         model->clearOverlayBuffer();
         for (auto &b : blocks) {
-            b.draw(model);
+            b.draw(model, brightness);
         }
-        paddle.draw(model);
-        ball.draw(model);
+        paddle.draw(model, brightness);
+        for (auto &ball : balls) {
+            int r = 255, g = 255, bl = 255;
+            int ix = static_cast<int>(std::round(ball.x));
+            int iy = static_cast<int>(std::round(ball.y));
+            int bw = std::max(1, static_cast<int>(std::round(ball.width)));
+            int bh = std::max(1, static_cast<int>(std::round(ball.height)));
+            for (int xp = 0; xp < bw; xp++) {
+                for (int yp = 0; yp < bh; yp++) {
+                    model->setOverlayPixelValue(ix + xp, iy + yp, r, g, bl);
+                }
+            }
+        }
+        for (auto &p : powerUps) {
+            p.draw(model);
+        }
+        for (auto &l : lasers) {
+            int ix = static_cast<int>(std::round(l.x));
+            int tip = static_cast<int>(std::round(l.y));
+            int start = std::clamp(tip - 3, 0, model->getHeight() - 1);
+            int end = std::clamp(tip + 1, 0, model->getHeight() - 1);
+            for (int y = end; y >= start; --y) {
+                model->setOverlayPixelValue(ix, y, 255, 0, 0);
+            }
+        }
         model->flushOverlayBuffer();
+    }
+
+    void updatePowerUps() {
+        auto it = powerUps.begin();
+        while (it != powerUps.end()) {
+            it->y += it->fallSpeed;
+            if (it->y >= model->getHeight()) {
+                it = powerUps.erase(it);
+                continue;
+            }
+            bool caught = (it->y + it->height) >= paddle.y &&
+                          (it->x + it->width) >= paddle.x &&
+                          it->x <= (paddle.x + paddle.width);
+            if (caught) {
+                applyPowerUp(it->type);
+                it = powerUps.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    void applyPowerUp(PowerUp::Type type) {
+        constexpr int durationMs = 8000;
+        switch (type) {
+            case PowerUp::Type::Expand:
+                paddle.width = std::min<float>(model->getWidth() * 0.8f,
+                                               paddle.width + basePaddleWidth * 0.5f);
+                expandTimerMs = durationMs;
+                enforcePaddleBounds();
+                break;
+            case PowerUp::Type::Slow:
+                ballSpeedMultiplier = 0.6f;
+                setAllBallSpeeds();
+                slowTimerMs = durationMs;
+                break;
+            case PowerUp::Type::Break:
+                powerBallActive = true;
+                breakTimerMs = durationMs;
+                break;
+            case PowerUp::Type::Sticky:
+                stickyActive = true;
+                stickyTimerMs = durationMs;
+                break;
+            case PowerUp::Type::Laser:
+                laserActive = true;
+                laserTimerMs = durationMs;
+                break;
+            case PowerUp::Type::Triple:
+                spawnTripleBalls();
+                break;
+        }
+    }
+
+    void enforcePaddleBounds() {
+        if (paddle.x < 0) {
+            paddle.x = 0;
+        }
+        if ((paddle.x + paddle.width) > model->getWidth()) {
+            paddle.x = model->getWidth() - paddle.width;
+        }
+    }
+
+    void updatePowerUpTimers() {
+        const int tick = 50;
+        if (slowTimerMs > 0) {
+            slowTimerMs -= tick;
+            if (slowTimerMs <= 0) {
+                ballSpeedMultiplier = 1.0f;
+                setAllBallSpeeds();
+            }
+        }
+        if (expandTimerMs > 0) {
+            expandTimerMs -= tick;
+            if (expandTimerMs <= 0) {
+                paddle.width = basePaddleWidth;
+                enforcePaddleBounds();
+            }
+        }
+        if (breakTimerMs > 0) {
+            breakTimerMs -= tick;
+            if (breakTimerMs <= 0) {
+                powerBallActive = false;
+            }
+        }
+        if (stickyTimerMs > 0) {
+            stickyTimerMs -= tick;
+            if (stickyTimerMs <= 0) {
+                releaseStuckBalls();
+            }
+        }
+        if (laserTimerMs > 0) {
+            laserTimerMs -= tick;
+            if (laserTimerMs <= 0) {
+                laserActive = false;
+            }
+        }
+    }
+
+    void setAllBallSpeeds() {
+        for (auto &ball : balls) {
+            ball.speed = baseBallSpeed * ballSpeedMultiplier;
+        }
+    }
+
+    void releaseStuckBalls(bool keepEffect = false) {
+        for (auto &ball : balls) {
+            if (ball.stuck) {
+                ball.stuck = false;
+                if (std::fabs(ball.directionY) < 0.1f) {
+                    ball.directionY = -0.75f;
+                }
+                if (ball.directionY > 0) {
+                    ball.directionY = -ball.directionY;
+                }
+                if (std::fabs(ball.directionX) < 0.05f) {
+                    ball.directionX = 0.2f;
+                }
+                vec2_norm(ball.directionX, ball.directionY);
+            }
+        }
+        if (!keepEffect) {
+            stickyActive = false;
+            stickyTimerMs = 0;
+        }
+    }
+
+    void spawnTripleBalls() {
+        std::vector<Ball> additions;
+        for (auto &ball : balls) {
+            Ball left = ball;
+            Ball right = ball;
+            left.stuck = right.stuck = false;
+            left.directionX -= 0.3f;
+            right.directionX += 0.3f;
+            left.directionY = -std::fabs(left.directionY == 0 ? 0.75f : left.directionY);
+            right.directionY = -std::fabs(right.directionY == 0 ? 0.75f : right.directionY);
+            vec2_norm(left.directionX, left.directionY);
+            vec2_norm(right.directionX, right.directionY);
+            left.speed = right.speed = baseBallSpeed * ballSpeedMultiplier;
+            additions.push_back(left);
+            additions.push_back(right);
+        }
+        balls.insert(balls.end(), additions.begin(), additions.end());
+    }
+
+    void fireLasers() {
+        if (!laserActive) {
+            return;
+        }
+        float centerX = paddle.x + paddle.width / 2.0f;
+        lasers.push_back({centerX, paddle.y - 1, 4.0f});
+    }
+
+    void updateLasers() {
+        auto it = lasers.begin();
+        while (it != lasers.end()) {
+            float prevY = it->y;
+            it->y -= it->speed;
+            if (it->y < 0) {
+                it = lasers.erase(it);
+                continue;
+            }
+
+            auto targetIt = blocks.end();
+            float bestBottom = -1;
+            for (auto brickIt = blocks.begin(); brickIt != blocks.end(); ++brickIt) {
+                if (it->x >= brickIt->left() && it->x <= brickIt->right()) {
+                    if (brickIt->bottom() < prevY && brickIt->bottom() > bestBottom) {
+                        bestBottom = brickIt->bottom();
+                        targetIt = brickIt;
+                    }
+                }
+            }
+            if (targetIt != blocks.end()) {
+                maybeSpawnPowerUp(*targetIt);
+                markBrickGone(targetIt->row, targetIt->col);
+                blocks.erase(targetIt);
+                it = lasers.erase(it);
+            } else {
+                ++it;
+            }
+        }
+    }
+
+    void removeLostBalls() {
+        balls.erase(std::remove_if(balls.begin(), balls.end(), [&](const Ball &ball) {
+            return ball.y >= model->getHeight();
+        }), balls.end());
+    }
+
+    int centeredTextX(const std::string &text, float scl) const {
+        if (scl <= 0) {
+            return 0;
+        }
+        int glyphWidth = 4;
+        int gridWidth = model->getWidth() / scl;
+        int textWidth = glyphWidth * static_cast<int>(text.size());
+        int pos = (gridWidth - textWidth) / 2;
+        if (pos < 0) {
+            pos = 0;
+        }
+        return pos;
     }
     
     virtual int32_t update() override {
@@ -185,32 +642,50 @@ public:
         } else if ((paddle.x + paddle.width) >= model->getWidth()) {
             paddle.x = model->getWidth() - paddle.width;
         }
-        moveBall();
-        
-        if (ball.intersects(paddle)) {
-            float t = ((ball.x - paddle.x) / paddle.width) - 0.5f;
-            ball.directionY = -std::fabs(ball.directionY);
-            ball.directionX = t;
+        moveBalls();
+        updatePowerUps();
+        updatePowerUpTimers();
+        updateLasers();
+
+        for (auto &ball : balls) {
+            if (ball.bottom() >= paddle.y && ball.left() <= (paddle.x + paddle.width) && ball.right() >= paddle.x && ball.directionY > 0) {
+                if (!stickyActive) {
+                    float t = ((ball.x - paddle.x) / paddle.width) - 0.5f;
+                    ball.directionY = -std::fabs(ball.directionY);
+                    ball.directionX = t;
+                    vec2_norm(ball.directionX, ball.directionY);
+                } else {
+                    ball.stuck = true;
+                    ball.directionX = 0;
+                    ball.directionY = 0;
+                    float ballCenter = ball.x + ball.width / 2.0f;
+                    float paddleCenter = paddle.x + paddle.width / 2.0f;
+                    ball.stickOffset = ballCenter - paddleCenter;
+                    ball.y = paddle.y - ball.height;
+                }
+            }
         }
         
         // make sure that length of dir stays at 1
-        vec2_norm(ball.directionX, ball.directionY);
+        removeLostBalls();
 
         CopyToModel();
-        if (ball.y >= model->getHeight()) {
+        if (balls.empty()) {
             //end game
             GameOn = false;
             float scl = paddle.height;
-            outputString("GAME", (model->getWidth()-(8 * scl))/ 2 / scl, (model->getHeight()/2-(6 * scl)) / scl, 255, 255, 255, scl);
-            outputString("OVER", (model->getWidth()-(8 * scl))/ 2 / scl, model->getHeight()/2 / scl, 255, 255, 255, scl);
+            CopyToModel(0.2f);
+            outputString("GAME", centeredTextX("GAME", scl), (model->getHeight()/2-(6 * scl)) / scl, 255, 255, 255, scl);
+            outputString("OVER", centeredTextX("OVER", scl), (model->getHeight()/2) / scl, 255, 255, 255, scl);
             model->flushOverlayBuffer();
             return 2000;
         }
         if (blocks.empty()) {
             GameOn = false;
             float scl = paddle.height;
-            outputString("YOU", (model->getWidth()-(6 * scl))/ 2 / scl, (model->getHeight()/2-(6 * scl)) / scl, 255, 255, 255, scl);
-            outputString("WIN", (model->getWidth()-(6 * scl))/ 2 / scl, model->getHeight()/2 / scl, 255, 255, 255, scl);
+            CopyToModel(0.2f);
+            outputString("YOU", centeredTextX("YOU", scl), (model->getHeight()/2-(6 * scl)) / scl, 255, 255, 255, scl);
+            outputString("WIN", centeredTextX("WIN", scl), (model->getHeight()/2) / scl, 255, 255, 255, scl);
             model->flushOverlayBuffer();
             return 2000;
         }
@@ -230,19 +705,46 @@ public:
         if (button == "Left - Pressed") {
             direction = -1;
         } else if (button == "Left - Released") {
-            direction = 0;
+            if (direction < 0) direction = 0;
         } else if (button == "Right - Pressed") {
             direction = 1;
         } else if (button == "Right - Released") {
-            direction = 0;
+            if (direction > 0) direction = 0;
+        } else if (button == "A Button - Pressed" || button == "B Button - Pressed") {
+            if (stickyActive) {
+                releaseStuckBalls(true);
+            }
+            if (laserActive) {
+                fireLasers();
+            }
         }
     }
     
-    Ball ball;
     Block paddle;
     std::list<Block> blocks;
+    std::vector<Ball> balls;
+    std::list<PowerUp> powerUps;
+    std::vector<Laser> lasers;
+    int brickRows = 0;
+    int brickCols = 0;
+    int brickWidth = 0;
+    int brickHeight = 0;
+    std::vector<float> columnStarts;
+    std::vector<float> rowStarts;
+    std::vector<std::vector<bool>> bricksAlive;
     
     int direction = 0;
+    float basePaddleWidth = 0;
+    float baseBallSpeed = 0;
+    float ballSpeedMultiplier = 1.0f;
+    int slowTimerMs = 0;
+    int expandTimerMs = 0;
+    int breakTimerMs = 0;
+    int stickyTimerMs = 0;
+    int laserTimerMs = 0;
+    bool powerBallActive = false;
+    bool stickyActive = false;
+    bool laserActive = false;
     
     bool GameOn = true;
     bool WaitingUntilOutput = false;

--- a/src/FPPFrogger.cpp
+++ b/src/FPPFrogger.cpp
@@ -1,0 +1,622 @@
+#include <fpp-pch.h>
+#include "FPPFrogger.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdlib>
+#include <ctime>
+#include <list>
+#include <random>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "overlays/PixelOverlay.h"
+#include "overlays/PixelOverlayModel.h"
+#include "overlays/PixelOverlayEffects.h"
+#include "log.h"
+
+// ------------------------------------------------------------
+// FPP Frogger (grid-based; settings-aware)
+// ------------------------------------------------------------
+// Settings (from plugin_setup.php):
+//   - Pixel Scaling: 1..20  -> each logical cell renders as SxS pixels
+//   - Lanes:        1..20   -> number of river lanes and road lanes
+//   - River Speed:  1..10   -> river band speed (logs/turtles)
+//   - Road  Speed:  1..10   -> road band speed (cars)
+//   - Speed Variability (%): 0..100 -> per-lane baseline jitter
+//
+// Notes:
+//   * Logical grid size = (panelW / scale) x (panelH / scale)
+//   * Lanes are single-row bands (river lanes, safe median, road lanes)
+//   * “Turtles” are a river mover variant (visual only), width fixed to 2
+//   * HUD (score/lives) draws in 1px raw physical pixels (unscaled)
+//   * All movers in the same lane share identical speed (no in-lane collisions)
+// ------------------------------------------------------------
+
+// --- speed mapping helper (1..10 -> ~0.6x..1.8x) ---
+static inline float mapSpeedInt(int s) {
+    s = std::max(1, std::min(10, s));
+    return 0.6f + (s - 1) * (1.2f / 9.0f);
+}
+
+struct FGEntity {
+    int gx = 0, gy = 0;  // grid position
+    int gw = 1, gh = 1;  // size in grid cells
+};
+
+struct FGLaneMover {
+    float gx = 0.0f;       // head X (float for smooth wrap)
+    int   gy = 0;          // lane row
+    int   gw = 2;          // width (cells)
+    int   dir = 1;         // +1 right, -1 left
+    float speed = 0.5f;    // cells/sec
+    bool  isLog = false;   // road=false, river=true
+    bool  isTurtle = false;// visual subtype of log (fixed width=2)
+    int   r=255, g=255, b=255;
+};
+
+class FroggerEffect : public FPPArcadeGameEffect {
+public:
+    struct Options {
+        int   scale        = 1;
+        int   lanes        = 5;
+        float riverMult    = 1.0f; // river (logs/turtles)
+        float roadMult     = 1.0f; // road (cars)
+        float variability  = 0.20f; // 0..1 lane-to-lane speed spread
+    };
+
+    explicit FroggerEffect(PixelOverlayModel *m, const Options &opts)
+        : FPPArcadeGameEffect(m), opt(opts)
+    {
+        opt.scale = std::clamp(opt.scale, 1, 20);
+        opt.lanes = std::clamp(opt.lanes, 1, 20);
+        opt.variability = std::clamp(opt.variability, 0.0f, 1.0f);
+
+        rng.seed((unsigned)time(nullptr) ^ (uintptr_t)this);
+        configureGrid();
+        resetGame(/*newGame=*/true);
+    }
+
+    ~FroggerEffect() override = default;
+
+    const std::string &name() const override {
+        static std::string NAME = "Frogger";
+        return NAME;
+    }
+
+    // Main loop
+    int32_t update() override {
+        constexpr double baseFrameMs = 50.0;
+        double elapsedMs = consumeElapsedMs(baseFrameMs);
+        if (elapsedMs <= 0.0) elapsedMs = baseFrameMs;
+        double frameScalar = std::clamp(elapsedMs / baseFrameMs, 0.1, 5.0);
+
+        if (!gameOn) {
+            model->clearOverlayBuffer();
+            drawGameOver();
+            model->flushOverlayBuffer();
+            if (!waitingUntilOutput) {
+                waitingUntilOutput = true;
+                return -1;
+            }
+            model->setState(PixelOverlayState(PixelOverlayState::PixelState::Disabled));
+            return 0;
+        }
+
+        if (paused) {
+            drawFrame(0.25f, /*drawPaused=*/true);
+            return 50;
+        }
+
+        advanceMovers((float)frameScalar);
+
+        // River: drown unless on a log/turtle (then get carried)
+        if (isRiverRow(frog.gy)) {
+            if (onAnyLog(frog)) {
+                float carry = laneDir(frog.gy) * laneSpeed(frog.gy) * (float)frameScalar;
+                carryFrog(carry);
+            } else {
+                loseLife();
+            }
+        }
+
+        // Road: car collision
+        if (isRoadRow(frog.gy) && hitByCar(frog)) {
+            loseLife();
+        }
+
+        // Home row: must land on a free slot
+        if (frog.gy == homeRow) {
+            int slot = nearestHomeSlot(frog.gx);
+            if (slot >= 0 && !homeFilled[slot]) {
+                homeFilled[slot] = true;
+                score += 50;
+                resetFrog();
+                if (std::all_of(homeFilled.begin(), homeFilled.end(), [](bool f){ return f; })) {
+                    level++;
+                    score += 100;
+                    initLevel();
+                }
+            } else {
+                loseLife(); // missed the slot -> water
+            }
+        }
+
+        drawFrame(1.0f);
+        return 50;
+    }
+
+    // Button handling
+    void button(const std::string &button) {
+        const bool isPress = (button.find("Pressed") != std::string::npos) || (button=="Fire");
+        if (!isPress) return;
+
+        const bool left   = (button=="Left - Pressed");
+        const bool right  = (button=="Right - Pressed");
+        const bool up     = (button=="Up - Pressed");
+        const bool down   = (button=="Down - Pressed");
+        const bool aPress =
+            (button=="A Button - Pressed") || (button=="B Button - Pressed") ||
+            (button=="Fire - Pressed")     || (button=="Fire") ||
+            (button=="Fire Button - Pressed");
+        const bool startPress = (button=="Start - Pressed") || (button=="Start");
+
+        if (startPress) {
+            if (!gameOn) {
+                resetGame(/*newGame=*/true);
+            } else {
+                paused = !paused;
+            }
+            return;
+        }
+
+        if (paused) return;
+
+        if (aPress || up)       moveFrog(0, -1);
+        else if (down)          moveFrog(0, +1);
+        else if (left)          moveFrog(-1, 0);
+        else if (right)         moveFrog(+1, 0);
+    }
+
+private:
+    // ------------ helpers ------------
+    int fittedLanesForGrid(int rowsLogical) const {
+        // rows needed = homes(1) + river(L) + median(1) + road(L) + start(1)
+        // => 2*L + 3  <= rowsLogical  =>  L <= (rowsLogical - 3)/2
+        int maxL = std::max(1, (rowsLogical - 3) / 2);
+        return std::max(1, std::min(opt.lanes, maxL));
+    }
+
+    // ------------ Grid/rows ------------
+    void configureGrid() {
+        // Apply pixel scaling to “logical” grid
+        cellW = cellH = std::max(1, opt.scale);
+
+        // logical cols/rows (min bounds keep game playable on tiny panels)
+        gridCols = std::max(30, model->getWidth()  / cellW);
+        gridRows = std::max(20, model->getHeight() / cellH);
+
+        // Fit lane count to available rows so start/home always exist
+        int L = fittedLanesForGrid(gridRows);
+
+        // rows: [homes][river x L][median][road x L][start]
+        homeRow       = 1;
+        riverTop      = 2;
+        riverBottom   = riverTop + L - 1;
+        safeMedianRow = riverBottom + 1;
+        roadTop       = safeMedianRow + 1;
+        roadBottom    = roadTop + L - 1;
+
+        // keep everything in range and place start just above bottom
+        roadBottom = std::min(roadBottom, gridRows - 3);
+        startRow   = std::min(roadBottom + 1, gridRows - 2);
+
+        // home slots
+        const int slots = 5;
+        homeSlots = slots;
+        homeX.clear();
+        homeFilled.assign(slots, false);
+        for (int i=0; i<slots; ++i) {
+            int cx = (i+1) * gridCols / (slots+1);
+            homeX.push_back(cx);
+        }
+
+        laneMult.assign(gridRows, 1.0f);
+    }
+
+    // ------------ Game state ------------
+    void resetGame(bool /*newGame*/) {
+        level  = 1;
+        score  = 0;
+        lives  = 3;
+        paused = false;
+        gameOn = true;
+        waitingUntilOutput = false;
+        initLevel();
+    }
+
+    void initLevel() {
+        std::fill(homeFilled.begin(), homeFilled.end(), false);
+        movers.clear();
+        buildRiver();
+        buildRoad();
+        reseedLaneMultipliers();
+        resetFrog();
+        resetFrameTimer();
+    }
+
+    void resetFrog() {
+        frog = {};
+        frog.gw = frog.gh = 1;
+        frog.gx = std::clamp(gridCols / 2, 0, gridCols - 1);
+        frog.gy = std::clamp(startRow,      0, gridRows - 1);
+    }
+
+    void loseLife() {
+        if (invulnTimerMs > 0.0) return; // grace
+        lives--;
+        LogInfo(VB_PLUGIN, "[Frogger] Life lost. Lives left=%d", lives);
+        if (lives < 0) {
+            gameOn = false;
+            return;
+        }
+        score = std::max(0, score - 25);
+        resetFrog();
+        invulnTimerMs = 800.0; // ms
+    }
+
+    // ------------ Lanes helpers ------------
+    bool isRiverRow(int gy) const { return gy >= riverTop && gy <= riverBottom; }
+    bool isRoadRow (int gy) const { return gy >= roadTop  && gy <= roadBottom; }
+
+    int laneDir(int gy) const { return ((gy % 2) == 0) ? +1 : -1; }
+
+    float laneSpeed(int gy) const {
+        const float bandBase = isRiverRow(gy) ? 0.45f : 0.60f;
+        const float levelAdj = 0.06f * (level - 1);
+        const float bandMult = isRiverRow(gy) ? opt.riverMult : opt.roadMult;
+        const float laneJit  = (gy >= 0 && gy < (int)laneMult.size()) ? laneMult[gy] : 1.0f;
+        return (bandBase + levelAdj) * bandMult * laneJit;
+    }
+
+    void reseedLaneMultipliers() {
+        const float v = std::clamp(opt.variability, 0.0f, 1.0f);
+        std::uniform_real_distribution<float> d(1.0f - v, 1.0f + v);
+        for (int gy = riverTop; gy <= riverBottom; ++gy) {
+            laneMult[gy] = std::clamp(d(rng), 0.2f, 3.0f);
+        }
+        for (int gy = roadTop; gy <= roadBottom; ++gy) {
+            laneMult[gy] = std::clamp(d(rng), 0.2f, 3.0f);
+        }
+    }
+
+    // ------------ Randomized lane population ------------
+    void buildRiver() {
+        std::uniform_int_distribution<int> wdist(4, 8);            // log length
+        std::uniform_int_distribution<int> spandist(8, 14);        // spacing
+        std::bernoulli_distribution turtleLane(0.45);              // lane may prefer turtles
+        std::bernoulli_distribution turtleMix(0.40);               // per-entity chance
+
+        for (int gy = riverTop; gy <= riverBottom; ++gy) {
+            const int   dir    = laneDir(gy);
+            const float laneS  = laneSpeed(gy); // lane-uniform speed
+            const int   span   = spandist(rng);
+            const int   count  = std::max(2, gridCols / span);
+            const bool  preferTurtles = turtleLane(rng);
+
+            int advance = 0;
+            for (int i=0; i<count; ++i) {
+                FGLaneMover m;
+                m.gy    = gy;
+                m.dir   = dir;
+                m.speed = std::max(0.15f, laneS); // same for entire lane
+                m.isLog = true;
+
+                // turtles fixed to width=2; logs keep random length
+                m.isTurtle = preferTurtles ? true : turtleMix(rng);
+                if (m.isTurtle) {
+                    m.gw = 2;
+                    m.r = 60;  m.g = 200; m.b = 200;   // bluish-green
+                } else {
+                    m.gw = wdist(rng);
+                    m.r = 100; m.g = 200; m.b = 100;   // greenish
+                }
+
+                // staggered start
+                int startCol = (advance % gridCols);
+                m.gx = (dir > 0) ? (float)startCol : (float)(gridCols - startCol);
+                advance += span;
+
+                movers.push_back(m);
+            }
+        }
+    }
+
+    void buildRoad() {
+        std::uniform_int_distribution<int> wdist(2, 5);           // car length
+        std::uniform_int_distribution<int> spandist(10, 16);      // spacing
+        std::uniform_int_distribution<int> colorPick(0, 4);
+
+        auto pickCarColor = [&](int &r, int &g, int &b) {
+            switch (colorPick(rng)) {
+                case 0: r=220; g=60;  b=60;  break; // red
+                case 1: r=60;  g=160; b=240; break; // blue
+                case 2: r=220; g=220; b=60;  break; // yellow
+                case 3: r=180; g=80;  b=220; break; // purple
+                default:r=120; g=220; b=90;  break; // lime
+            }
+        };
+
+        for (int gy = roadTop; gy <= roadBottom; ++gy) {
+            const int   dir    = laneDir(gy);
+            const float laneS  = laneSpeed(gy); // lane-uniform speed
+            const int   span   = spandist(rng);
+            const int   count  = std::max(2, gridCols / span);
+
+            int advance = 0;
+            for (int i=0; i<count; ++i) {
+                FGLaneMover m;
+                m.gy    = gy;
+                m.gw    = wdist(rng);
+                m.dir   = dir;
+                m.speed = std::max(0.20f, laneS); // same for entire lane
+                m.isLog = false;
+                pickCarColor(m.r, m.g, m.b);
+
+                int startCol = (advance % gridCols);
+                m.gx = (dir > 0) ? (float)startCol : (float)(gridCols - startCol);
+                advance += span;
+
+                movers.push_back(m);
+            }
+        }
+    }
+
+    void advanceMovers(float frameScalar) {
+        double elapsedMs = frameScalar * 50.0;
+        if (invulnTimerMs > 0.0) {
+            invulnTimerMs -= elapsedMs;
+            if (invulnTimerMs < 0.0) invulnTimerMs = 0.0;
+        }
+
+        const float dt = (float)(elapsedMs / 1000.0); // seconds
+        for (auto &m : movers) {
+            m.gx += m.dir * m.speed * dt;
+            const float wrap = (float)(gridCols + m.gw);
+            if (m.gx < -m.gw)      m.gx += wrap;
+            if (m.gx > wrap)       m.gx -= wrap;
+        }
+    }
+
+    // collisions
+    static bool rectOverlap(int ax,int ay,int aw,int ah,
+                            int bx,int by,int bw,int bh) {
+        return (ax < bx + bw) && (ax + aw > bx) &&
+               (ay < by + bh) && (ay + ah > by);
+    }
+
+    bool onAnyLog(const FGEntity &f) const {
+        for (const auto &m : movers) {
+            if (!m.isLog || m.gy != f.gy) continue;
+            int mx = (int)std::floor(m.gx + 0.5f);
+            if (rectOverlap(f.gx, f.gy, f.gw, f.gh, mx, m.gy, m.gw, 1))
+                return true;
+        }
+        return false;
+    }
+
+    bool hitByCar(const FGEntity &f) const {
+        for (const auto &m : movers) {
+            if (m.isLog || m.gy != f.gy) continue;
+            int mx = (int)std::floor(m.gx + 0.5f);
+            if (rectOverlap(f.gx, f.gy, f.gw, f.gh, mx, m.gy, m.gw, 1))
+                return true;
+        }
+        return false;
+    }
+
+    void carryFrog(float dx) {
+        float nx = frog.gx + dx;
+        int ix   = (int)std::round(nx);
+        frog.gx  = std::clamp(ix, 0, gridCols - 1);
+        if (frog.gx <= 0 || frog.gx >= gridCols - 1) {
+            loseLife(); // fell off screen
+        }
+    }
+
+    void moveFrog(int dx, int dy) {
+        frog.gx = std::clamp(frog.gx + dx, 0, gridCols - 1);
+        frog.gy = std::clamp(frog.gy + dy, 0, gridRows - 1);
+        if (dy < 0) score += 1; // reward forward hops
+    }
+
+    // homes
+    int nearestHomeSlot(int gx) const {
+        int best=-1, bestDist=9999;
+        for (int i=0; i<(int)homeX.size(); ++i) {
+            int d = std::abs(gx - homeX[i]);
+            if (d < bestDist && d <= 1) { best = i; bestDist = d; }
+        }
+        return best;
+    }
+
+    // -------- Rendering with pixel scaling --------
+    inline void pxRaw(int x,int y,int r,int g,int b) {
+        if (x<0||y<0||x>=model->getWidth()||y>=model->getHeight()) return;
+        model->setOverlayPixelValue(x,y,r,g,b);
+    }
+
+    inline void fillCell(int gx,int gy,int r,int g,int b) {
+        // draw an opt.scale x opt.scale block
+        const int x0 = gx * cellW;
+        const int y0 = gy * cellH;
+        for (int yy=0; yy<cellH; ++yy) {
+            for (int xx=0; xx<cellW; ++xx) {
+                pxRaw(x0 + xx, y0 + yy, r, g, b);
+            }
+        }
+    }
+
+    void drawRectGrid(int gx,int gy,int gw,int gh,int r,int g,int b,float bright=1.0f) {
+        const int rr = std::clamp((int)(r*bright),0,255);
+        const int gg = std::clamp((int)(g*bright),0,255);
+        const int bb = std::clamp((int)(b*bright),0,255);
+        for (int yy=0; yy<gh; ++yy)
+            for (int xx=0; xx<gw; ++xx)
+                fillCell(gx + xx, gy + yy, rr, gg, bb);
+    }
+
+    void drawFrame(float brightness, bool drawPaused=false) {
+        model->clearOverlayBuffer();
+
+        // background bands
+        for (int gy=0; gy<gridRows; ++gy) {
+            int r=0,g=0,b=0;
+            if (gy==homeRow)            { r=30; g=30; b=30; }
+            else if (isRiverRow(gy))    { r=10; g=10; b=40; }
+            else if (gy==safeMedianRow) { r=20; g=20; b=20; }
+            else if (isRoadRow(gy))     { r=30; g=30; b=30; }
+            for (int gx=0; gx<gridCols; ++gx)
+                drawRectGrid(gx, gy, 1, 1,
+                             (int)(r*brightness),(int)(g*brightness),(int)(b*brightness), 1.0f);
+        }
+
+        // homes
+        for (int i=0; i<(int)homeX.size(); ++i) {
+            int hx = homeX[i];
+            int r = homeFilled[i] ? 0   : 80;
+            int g = homeFilled[i] ? 200 : 80;
+            int b = homeFilled[i] ? 0   : 80;
+            drawRectGrid(hx, homeRow, 1, 1, r,g,b, brightness);
+        }
+
+        // movers
+        for (auto &m : movers) {
+            int mx = (int)std::floor(m.gx + 0.5f);
+            drawRectGrid(mx, m.gy, m.gw, 1, m.r, m.g, m.b, brightness);
+        }
+
+        // frog (blink during invulnerability)
+        float frogBright = brightness;
+        if (invulnTimerMs>0.0 && ((int)(invulnTimerMs/100) % 2)==0) frogBright *= 0.35f;
+        drawRectGrid(frog.gx, frog.gy, 1, 1, 255,255,255, frogBright);
+
+        // --- HUD as 1px raw pixels (unscaled) ---
+        const int panelW = model->getWidth();
+        const int panelH = model->getHeight();
+
+        // score dots across the top physical row (y=0)
+        int dots = std::min((score/10) % panelW, panelW - 1);
+        for (int i=0; i<dots; ++i) pxRaw(i, 0, 200,200,200);
+
+        // lives as dots on bottom physical row (y=panelH-1)
+        int yLives = panelH - 1;
+        int xLives = 0;
+        for (int i=0; i<std::max(0,lives); ++i) {
+            pxRaw(xLives, yLives, 255,255,255);
+            xLives += 2; // spacing
+            if (xLives >= panelW) break;
+        }
+
+        if (drawPaused) {
+            outputString("PAUSED", centerTextX("PAUSED"), std::max(0, gridRows/2-3), 255,255,255, 1);
+        }
+
+        model->flushOverlayBuffer();
+    }
+
+    int centerTextX(const std::string &text) const {
+        const int glyphWidth = 4;
+        const int textWidth  = glyphWidth * (int)text.size();
+        int pos = (gridCols - textWidth) / 2;
+        return std::max(0, pos);
+    }
+
+    void drawGameOver() {
+        drawFrame(0.2f, false);
+        outputString("GAME",  centerTextX("GAME"),  std::max(0, gridRows/2 - 6), 255,255,255, 1);
+        outputString("OVER",  centerTextX("OVER"),  std::max(0, gridRows/2),     255,255,255, 1);
+    }
+
+private:
+    // grid
+    int gridCols=60, gridRows=25;
+    int cellW=1, cellH=1;
+
+    // rows
+    int homeRow=1;
+    int riverTop=3, riverBottom=10;
+    int safeMedianRow=12;
+    int roadTop=14, roadBottom=22;
+    int startRow=23;
+
+    // homes
+    int homeSlots=5;
+    std::vector<int>  homeX;
+    std::vector<bool> homeFilled;
+
+    // entities
+    FGEntity frog;
+    std::vector<FGLaneMover> movers;
+
+    // state
+    int    level=1;
+    int    lives=3;
+    int    score=0;
+    bool   paused=false;
+    bool   gameOn=true;
+    bool   waitingUntilOutput=false;
+    double invulnTimerMs=0.0;
+
+    // per-lane variability multiplier (baseline)
+    std::vector<float> laneMult;
+
+    Options opt;
+    std::mt19937 rng;
+};
+
+// --------- FPPFrogger methods (wrapper) ---------
+
+const std::string &FPPFrogger::getName() {
+    static const std::string name = "Frogger";
+    return name;
+}
+
+void FPPFrogger::button(const std::string &button) {
+    PixelOverlayModel *m = PixelOverlayManager::INSTANCE.getModel(modelName);
+    if (!m) return;
+
+    auto *effect = dynamic_cast<FroggerEffect*>(m->getRunningEffect());
+    if (!effect) {
+        // read settings from the JSON row
+        FroggerEffect::Options opts;
+
+        // Pixel Scaling
+        try { opts.scale = std::max(1, std::min(20, std::stoi(findOption("Pixel Scaling", "1")))); } catch (...) {}
+
+        // Lanes (river+road count)
+        try { opts.lanes = std::max(1, std::min(20, std::stoi(findOption("Lanes", "5")))); } catch (...) {}
+
+        // River & Road speeds (no legacy global)
+        try { opts.riverMult = mapSpeedInt(std::stoi(findOption("River Speed", "1"))); } catch (...) {}
+        try { opts.roadMult  = mapSpeedInt(std::stoi(findOption("Road Speed",  "1"))); } catch (...) {}
+
+        // Speed Variability (% -> 0..1)
+        try {
+            int vpc = std::max(0, std::min(100, std::stoi(findOption("Speed Variability", "20"))));
+            opts.variability = vpc / 100.0f;
+        } catch (...) {}
+
+        if (findOption("overlay", "Overwrite") == "Transparent") {
+            m->setState(PixelOverlayState(PixelOverlayState::PixelState::TransparentRGB));
+        } else {
+            m->setState(PixelOverlayState(PixelOverlayState::PixelState::Enabled));
+        }
+        effect = new FroggerEffect(m, opts);
+        m->setRunningEffect(effect, 50);
+    } else {
+        effect->button(button);
+    }
+}

--- a/src/FPPFrogger.h
+++ b/src/FPPFrogger.h
@@ -1,0 +1,11 @@
+#ifndef FPPFROGGER_H
+#define FPPFROGGER_H
+#include "FPPArcade.h"
+class FPPFrogger : public FPPArcadeGame {
+public:
+    FPPFrogger(Json::Value &config) : FPPArcadeGame(config) {}
+    ~FPPFrogger() override = default;
+    const std::string &getName() override;
+    void button(const std::string &button) override;
+};
+#endif

--- a/src/FPPPong.cpp
+++ b/src/FPPPong.cpp
@@ -265,8 +265,8 @@ void FPPPong::button(const std::string &button) {
             } else {
                 m->setState(PixelOverlayState(PixelOverlayState::PixelState::Enabled));
             }
-            int controls = std::stoi(findOption("Controls", "1"));
             int pixelScaling = std::stoi(findOption("Pixel Scaling", "1"));
+            int controls = std::stoi(findOption("Controls", "1"));
             effect = new PongEffect(pixelScaling, controls, m);
             effect->button(button);
             m->setRunningEffect(effect, 50);

--- a/src/FPPSnake.cpp
+++ b/src/FPPSnake.cpp
@@ -152,11 +152,12 @@ public:
         CopyToModel();
         if (!GameOn) {
             GameOn = false;
-            outputString("GAME", cols/ 2 - 8, rows/2-9);
-            outputString("OVER", cols/ 2 - 8, rows/2-3);
+            int scl = scale == 0 ? 1 : scale;
+            outputString("GAME", centerTextX("GAME", scl), rows/2-9, 255, 255, 255, scl);
+            outputString("OVER", centerTextX("OVER", scl), rows/2-3, 255, 255, 255, scl);
             char buf[25];
             sprintf(buf, "%d", (uint32_t)snake.size());
-            outputString(buf, (cols)/ 2 - 4, rows/2+3);
+            outputString(buf, centerTextX(buf, scl), rows/2+3, 255, 255, 255, scl);
             model->flushOverlayBuffer();
             return 2000;
         }
@@ -166,13 +167,13 @@ public:
     
     
     void button(const std::string &button) {
-        if (button == "Left - Pressed") {
+        if (button == "Left - Pressed" && direction != 2) {
             direction = 0;
-        } else if (button == "Right - Pressed") {
+        } else if (button == "Right - Pressed" && direction != 0) {
             direction = 2;
-        } else if (button == "Up - Pressed") {
+        } else if (button == "Up - Pressed" && direction != 3) {
             direction = 1;
-        } else if (button == "Down - Pressed") {
+        } else if (button == "Down - Pressed" && direction != 1) {
             direction = 3;
         }
     }


### PR DESCRIPTION
- Added dedicated `A Button` and `B Button` controller bindings in the command list and web UI.
- Updated joystick defaults to map common gamepad buttons 0/1 to the new A/B bindings.
- In Tetris, `A Button` (or `Up`) now rotates clockwise while `B Button` rotates counter-clockwise.
- Breakout now uses gap-aware brick collisions that prevent the ball from slipping between bricks.
- Refactored Breakout to support multiple simultaneous balls and added new Sticky, Laser, Break, Expand, Slow, and Triple power-ups that randomly drop from destroyed bricks, fall toward the paddle, and apply temporary effects (press A/B to release stuck balls or fire lasers).
- Dim and center the Game Over / You Win overlays in Breakout for improved readability.
- Tetris lateral movement now repeats while holding left/right, and the Game Over screen (and Snake’s) is centered along with the score.