### PR TITLE
Add multiplayer support for Pong

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SRCDIR ?= /opt/fpp/src
 include $(SRCDIR)/makefiles/common/setup.mk
 include $(SRCDIR)/makefiles/platform/*.mk
 
-all: libfpp-arcade.$(SHLIB_EXT)
+all: libfpp-arcade2.$(SHLIB_EXT)
 debug: all
 
 CFLAGS+=-I.
@@ -14,9 +14,9 @@ CXXFLAGS_src/FPPArcade.o += -I$(SRCDIR)
 %.o: %.cpp Makefile
 	$(CCACHE) $(CC) $(CFLAGS) $(CXXFLAGS) $(CXXFLAGS_$@) -c $< -o $@
 
-libfpp-arcade.$(SHLIB_EXT): $(OBJECTS_fpp_arcade_so) $(SRCDIR)/libfpp.$(SHLIB_EXT)
+libfpp-arcade2.$(SHLIB_EXT): $(OBJECTS_fpp_arcade_so) $(SRCDIR)/libfpp.$(SHLIB_EXT)
 	$(CCACHE) $(CC) -shared $(CFLAGS_$@) $(OBJECTS_fpp_arcade_so) $(LIBS_fpp_arcade_so) $(LDFLAGS) -o $@
 
 clean:
-	rm -f libfpp-arcade.so $(OBJECTS_fpp_arcade_so)
+	rm -f libfpp-arcade2.so $(OBJECTS_fpp_arcade_so)
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SRCDIR ?= /opt/fpp/src
 include $(SRCDIR)/makefiles/common/setup.mk
 include $(SRCDIR)/makefiles/platform/*.mk
 
-all: libfpp-arcade2.$(SHLIB_EXT)
+all: libfpp-arcade.$(SHLIB_EXT)
 debug: all
 
 CFLAGS+=-I.
@@ -14,9 +14,9 @@ CXXFLAGS_src/FPPArcade.o += -I$(SRCDIR)
 %.o: %.cpp Makefile
 	$(CCACHE) $(CC) $(CFLAGS) $(CXXFLAGS) $(CXXFLAGS_$@) -c $< -o $@
 
-libfpp-arcade2.$(SHLIB_EXT): $(OBJECTS_fpp_arcade_so) $(SRCDIR)/libfpp.$(SHLIB_EXT)
+libfpp-arcade.$(SHLIB_EXT): $(OBJECTS_fpp_arcade_so) $(SRCDIR)/libfpp.$(SHLIB_EXT)
 	$(CCACHE) $(CC) -shared $(CFLAGS_$@) $(OBJECTS_fpp_arcade_so) $(LIBS_fpp_arcade_so) $(LDFLAGS) -o $@
 
 clean:
-	rm -f libfpp-arcade2.so $(OBJECTS_fpp_arcade_so)
+	rm -f libfpp-arcade.so $(OBJECTS_fpp_arcade_so)
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+#FPP arcade V2

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -2,7 +2,7 @@
 	"repoName": "fpp-arcade2",
 	"name": "FPP Arcade Multi-Player",
 	"author": "Daniel Kulp",
-	"description": "Various Games to Play on FPP Pixel Overlay Models",
+	"description": "Various Games to Play on FPP Pixel Overlay Models.  Enables Multi-Player functionality for games that support it. (Currently only Pong).",
 	"homeURL": "https://github.com/schreyack/fpp-arcade",
 	"srcURL": "https://github.com/schreyack/fpp-arcade.git",
 	"bugURL": "https://github.com/schreyack/fpp-arcade/issues",

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,6 +1,6 @@
 {
 	"repoName": "fpp-arcade2",
-	"name": "FPP Arcade 2",
+	"name": "FPP Arcade Multi-Player",
 	"author": "Daniel Kulp",
 	"description": "Various Games to Play on FPP Pixel Overlay Models",
 	"homeURL": "https://github.com/schreyack/fpp-arcade",

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,6 +1,6 @@
 {
-	"repoName": "fpp-arcade",
-	"name": "FPP Arcade",
+	"repoName": "fpp-arcade2",
+	"name": "FPP Arcade 2",
 	"author": "Daniel Kulp",
 	"description": "Various Games to Play on FPP Pixel Overlay Models",
 	"homeURL": "https://github.com/schreyack/fpp-arcade",

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,6 +1,6 @@
 {
 	"repoName": "fpp-arcade",
-	"name": "FPP Arcade",
+	"name": "FPP Arcade 2",
 	"author": "Daniel Kulp",
 	"description": "Various Games to Play on FPP Pixel Overlay Models",
 	"homeURL": "https://github.com/schreyack/fpp-arcade",

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,5 +1,5 @@
 {
-	"repoName": "fpp-arcade",
+	"repoName": "fpp-arcade2",
 	"name": "FPP Arcade 2",
 	"author": "Daniel Kulp",
 	"description": "Various Games to Play on FPP Pixel Overlay Models",

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -1,6 +1,6 @@
 {
-	"repoName": "fpp-arcade2",
-	"name": "FPP Arcade 2",
+	"repoName": "fpp-arcade",
+	"name": "FPP Arcade",
 	"author": "Daniel Kulp",
 	"description": "Various Games to Play on FPP Pixel Overlay Models",
 	"homeURL": "https://github.com/schreyack/fpp-arcade",

--- a/pluginInfo.json
+++ b/pluginInfo.json
@@ -3,9 +3,9 @@
 	"name": "FPP Arcade",
 	"author": "Daniel Kulp",
 	"description": "Various Games to Play on FPP Pixel Overlay Models",
-	"homeURL": "https://github.com/FalconChristmas/fpp-arcade",
-	"srcURL": "https://github.com/FalconChristmas/fpp-arcade.git",
-	"bugURL": "https://github.com/FalconChristmas/fpp-arcade/issues",
+	"homeURL": "https://github.com/schreyack/fpp-arcade",
+	"srcURL": "https://github.com/schreyack/fpp-arcade.git",
+	"bugURL": "https://github.com/schreyack/fpp-arcade/issues",
 	"versions": [
         {
             "minFPPVersion": "4.0",

--- a/plugin_setup.php
+++ b/plugin_setup.php
@@ -47,7 +47,7 @@ function GetPongOptions() {
     html += "<option value='1'>Up/Down and Left/Right</option>";
     html += "<option value='2'>UpLeft/DownLeft and UpRight/DownRight</option>";
     html += "<option value='3'>Up/Left and Right/Down </option>";
-    html += "<option value='4' selected>Up/Down separate joysticks </option>";
+    html += "<option value='4' selected>Multi-Player</option>";
     html += "</select>"
     return html;
 }

--- a/plugin_setup.php
+++ b/plugin_setup.php
@@ -47,6 +47,7 @@ function GetPongOptions() {
     html += "<option value='1'>Up/Down and Left/Right</option>";
     html += "<option value='2'>UpLeft/DownLeft and UpRight/DownRight</option>";
     html += "<option value='3'>Up/Left and Right/Down </option>";
+    html += "<option value='4'>Up/Down separate joysticks </option>";
     html += "</select>"
     return html;
 }

--- a/plugin_setup.php
+++ b/plugin_setup.php
@@ -47,7 +47,7 @@ function GetPongOptions() {
     html += "<option value='1'>Up/Down and Left/Right</option>";
     html += "<option value='2'>UpLeft/DownLeft and UpRight/DownRight</option>";
     html += "<option value='3'>Up/Left and Right/Down </option>";
-    html += "<option value='4'>Up/Down separate joysticks </option>";
+    html += "<option value='4' selected>Up/Down separate joysticks </option>";
     html += "</select>"
     return html;
 }

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -183,9 +183,9 @@ void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &
     if (btn != "") {
         if (joystickName!=""){
             btn += "|"+joystickName;
-            std::string msg = "Plugin log (FPPArcadeGame::axis): "+btn;
-            std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
-            log << msg << std::endl;
+            //std::string msg = "Plugin log (FPPArcadeGame::axis): "+btn;
+            //std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+            //log << msg << std::endl;
         }
         button(btn);
     }
@@ -404,9 +404,9 @@ public:
         const std::string model = args.size() > 1 ? args[1] : "";
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
         const std::string joystickName = args.size()>3 ? args[3] : "";
-        std::string msg = "Plugin log (runAxisCommand): "+joystickName;
-        std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
-        log << msg << std::endl;
+        //std::string msg = "Plugin log (runAxisCommand): "+joystickName;
+        //std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+        //log << msg << std::endl;
 
         if (model != "") {
             if (!games[model].empty()) {

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -397,6 +397,8 @@ public:
         const std::string axis = args[0];
         const std::string model = args.size() > 1 ? args[1] : "";
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
+        const std::string joystickName = args.size()>3 ? args[3] : "";
+        lastEvents.push_back("FPP Processed joystick name: "+joystickName);
 
         if (model != "") {
             if (!games[model].empty()) {

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -141,7 +141,7 @@ void FPPArcadeGame::stop() {
     }
 }
 //default behavior will map the axis directions to button presses
-void FPPArcadeGame::axis(const std::string &axis, int value) {
+void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &joystickName = "") {
     std::string btn = "";
     if (axis == AXIS[2]) { // DOWN->UP
         if (value == 0 && lastValues[0] < 0) {
@@ -181,6 +181,10 @@ void FPPArcadeGame::axis(const std::string &axis, int value) {
         lastValues[1] = value;
     }
     if (btn != "") {
+        if (joystickName!=""){
+            btn += "|"+joystickName;
+            printf("Plugin log (FPPArcadeGame::axis): "+btn+"!\n");
+        }
         button(btn);
     }
 }
@@ -398,8 +402,7 @@ public:
         const std::string model = args.size() > 1 ? args[1] : "";
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
         const std::string joystickName = args.size()>3 ? args[3] : "";
-        std::string s = "FPP Processed joystick name: "+joystickName;
-        lastEvents.push_back(s);
+        printf("Plugin log (runAxisCommand): "+joystickName+"!\n");
 
         if (model != "") {
             if (!games[model].empty()) {
@@ -408,7 +411,7 @@ public:
         } else {
             for (auto &a : games) {
                 if (!a.second.empty()) {
-                    a.second.front()->axis(axis, value);
+                    a.second.front()->axis(axis, value,joystickName);
                 }
             }
         }
@@ -590,8 +593,6 @@ public:
                     if (colonPos != std::string::npos) {
                         val["args"][3] = ev.substr(0, colonPos);
                     }
-                    std::string s = "FPP Arcade Axis joystick name: "+ev.substr(0, colonPos);
-                    lastEvents.push_back(s);
                     CommandManager::INSTANCE.run(val);
                 } else {
                     CommandManager::INSTANCE.run(f->second);

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -141,7 +141,7 @@ void FPPArcadeGame::stop() {
     }
 }
 //default behavior will map the axis directions to button presses
-void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &joystickName = "") {
+void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &joystickName) {
     std::string btn = "";
     if (axis == AXIS[2]) { // DOWN->UP
         if (value == 0 && lastValues[0] < 0) {

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -183,9 +183,6 @@ void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &
     if (btn != "") {
         if (joystickName!=""){
             btn += "|"+joystickName;
-            //std::string msg = "Plugin log (FPPArcadeGame::axis): "+btn;
-            //std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
-            //log << msg << std::endl;
         }
         button(btn);
     }
@@ -404,10 +401,6 @@ public:
         const std::string model = args.size() > 1 ? args[1] : "";
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
         const std::string joystickName = args.size()>3 ? args[3] : "";
-        //std::string msg = "Plugin log (runAxisCommand): "+joystickName;
-        //std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
-        //log << msg << std::endl;
-
         if (model != "") {
             if (!games[model].empty()) {
                 games[model].front()->axis(axis, value);

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -582,10 +582,10 @@ public:
                     Json::Value val = f->second;
                     val["args"][2] = std::to_string(value);
                     //add controller name
-                    val["controler"]="";
+                    val["args"].append("");
                     size_t colonPos = ev.find(':');
                     if (colonPos != std::string::npos) {
-                        val["controler"] = ev.substr(0, colonPos);
+                        val["args"][3] = ev.substr(0, colonPos);
                     }
                     CommandManager::INSTANCE.run(val);
                 } else {

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -184,7 +184,8 @@ void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &
         if (joystickName!=""){
             btn += "|"+joystickName;
             std::string msg = "Plugin log (FPPArcadeGame::axis): "+btn;
-            printf("%s\n",msg.c_str());
+            std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+            log << msg << std::endl;
         }
         button(btn);
     }
@@ -404,7 +405,8 @@ public:
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
         const std::string joystickName = args.size()>3 ? args[3] : "";
         std::string msg = "Plugin log (runAxisCommand): "+joystickName;
-        printf("%s\n",msg.c_str());
+        std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+        log << msg << std::endl;
 
         if (model != "") {
             if (!games[model].empty()) {

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -589,6 +589,7 @@ public:
                     if (colonPos != std::string::npos) {
                         val["args"][3] = ev.substr(0, colonPos);
                     }
+                    lastEvents.push_back("FPP Arcade Axis joystick name: "+val["args"][3]);
                     CommandManager::INSTANCE.run(val);
                 } else {
                     CommandManager::INSTANCE.run(f->second);

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -184,7 +184,7 @@ void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &
         if (joystickName!=""){
             btn += "|"+joystickName;
             //std::string msg = "Plugin log (FPPArcadeGame::axis): "+btn;
-            //std::ofstream log("/home/fpp/media/plugins/fpp-arcade/log", std::ios::app);
+            //std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
             //log << msg << std::endl;
         }
         button(btn);
@@ -405,7 +405,7 @@ public:
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
         const std::string joystickName = args.size()>3 ? args[3] : "";
         //std::string msg = "Plugin log (runAxisCommand): "+joystickName;
-        //std::ofstream log("/home/fpp/media/plugins/fpp-arcade/log", std::ios::app);
+        //std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
         //log << msg << std::endl;
 
         if (model != "") {

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -184,7 +184,7 @@ void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &
         if (joystickName!=""){
             btn += "|"+joystickName;
             //std::string msg = "Plugin log (FPPArcadeGame::axis): "+btn;
-            //std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+            //std::ofstream log("/home/fpp/media/plugins/fpp-arcade/log", std::ios::app);
             //log << msg << std::endl;
         }
         button(btn);
@@ -405,7 +405,7 @@ public:
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
         const std::string joystickName = args.size()>3 ? args[3] : "";
         //std::string msg = "Plugin log (runAxisCommand): "+joystickName;
-        //std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+        //std::ofstream log("/home/fpp/media/plugins/fpp-arcade/log", std::ios::app);
         //log << msg << std::endl;
 
         if (model != "") {

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -581,6 +581,12 @@ public:
                 if (f->second["command"] == "FPP Arcade Axis") {
                     Json::Value val = f->second;
                     val["args"][2] = std::to_string(value);
+                    //add controller name
+                    val["controler"]="";
+                    size_t colonPos = ev.find(':');
+                    if (colonPos != std::string::npos) {
+                        val["controler"] = ev.substr(0, colonPos);
+                    }
                     CommandManager::INSTANCE.run(val);
                 } else {
                     CommandManager::INSTANCE.run(f->second);

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -398,7 +398,8 @@ public:
         const std::string model = args.size() > 1 ? args[1] : "";
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
         const std::string joystickName = args.size()>3 ? args[3] : "";
-        lastEvents.push_back("FPP Processed joystick name: "+joystickName);
+        std::string s = "FPP Processed joystick name: "+joystickName;
+        lastEvents.push_back(s);
 
         if (model != "") {
             if (!games[model].empty()) {
@@ -479,7 +480,7 @@ public:
                         s += " - ";
                         s += "axis: " + std::to_string(ae->axis);
                         s += ", value: " + std::to_string(ae->value);
-                        lastEvents.push_back(s+' axis');
+                        lastEvents.push_back(s);
                         while (lastEvents.size() > 20) {
                             lastEvents.pop_front();
                         }
@@ -498,7 +499,7 @@ public:
                         s += " - ";
                         s += "button: " + std::to_string(be->button);
                         s += ", value: " + std::to_string(be->state);
-                        lastEvents.push_back(s+' button');
+                        lastEvents.push_back(s);
                         while (lastEvents.size() > 20) {
                             lastEvents.pop_front();
                         }
@@ -558,7 +559,7 @@ public:
                             s += "axis: " + std::to_string(ev.number);
                         }
                         s += ", value: " + std::to_string(ev.value);
-                        lastEvents.push_back(s+' callback');
+                        lastEvents.push_back(s);
                         while (lastEvents.size() > 20) {
                             lastEvents.pop_front();
                         }
@@ -589,7 +590,8 @@ public:
                     if (colonPos != std::string::npos) {
                         val["args"][3] = ev.substr(0, colonPos);
                     }
-                    lastEvents.push_back("FPP Arcade Axis joystick name: "+val["args"][3]);
+                    std::string s = "FPP Arcade Axis joystick name: "+val["args"][3];
+                    lastEvents.push_back(s);
                     CommandManager::INSTANCE.run(val);
                 } else {
                     CommandManager::INSTANCE.run(f->second);

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -558,7 +558,7 @@ public:
                             s += "axis: " + std::to_string(ev.number);
                         }
                         s += ", value: " + std::to_string(ev.value);
-                        lastEvents.push_back(s);
+                        lastEvents.push_back(s+' oyoung');
                         while (lastEvents.size() > 20) {
                             lastEvents.pop_front();
                         }

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -479,7 +479,7 @@ public:
                         s += " - ";
                         s += "axis: " + std::to_string(ae->axis);
                         s += ", value: " + std::to_string(ae->value);
-                        lastEvents.push_back(s);
+                        lastEvents.push_back(s+' axis');
                         while (lastEvents.size() > 20) {
                             lastEvents.pop_front();
                         }
@@ -498,7 +498,7 @@ public:
                         s += " - ";
                         s += "button: " + std::to_string(be->button);
                         s += ", value: " + std::to_string(be->state);
-                        lastEvents.push_back(s);
+                        lastEvents.push_back(s+' button');
                         while (lastEvents.size() > 20) {
                             lastEvents.pop_front();
                         }
@@ -558,7 +558,7 @@ public:
                             s += "axis: " + std::to_string(ev.number);
                         }
                         s += ", value: " + std::to_string(ev.value);
-                        lastEvents.push_back(s+' oyoung');
+                        lastEvents.push_back(s+' callback');
                         while (lastEvents.size() > 20) {
                             lastEvents.pop_front();
                         }

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -590,7 +590,7 @@ public:
                     if (colonPos != std::string::npos) {
                         val["args"][3] = ev.substr(0, colonPos);
                     }
-                    std::string s = "FPP Arcade Axis joystick name: "+val["args"][3];
+                    std::string s = "FPP Arcade Axis joystick name: "+ev.substr(0, colonPos);
                     lastEvents.push_back(s);
                     CommandManager::INSTANCE.run(val);
                 } else {

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -183,7 +183,8 @@ void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &
     if (btn != "") {
         if (joystickName!=""){
             btn += "|"+joystickName;
-            printf("Plugin log (FPPArcadeGame::axis): "+btn+"!\n");
+            std::string msg = "Plugin log (FPPArcadeGame::axis): "+btn;
+            printf("%s\n",msg.c_str());
         }
         button(btn);
     }
@@ -402,7 +403,8 @@ public:
         const std::string model = args.size() > 1 ? args[1] : "";
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
         const std::string joystickName = args.size()>3 ? args[3] : "";
-        printf("Plugin log (runAxisCommand): "+joystickName+"!\n");
+        std::string msg = "Plugin log (runAxisCommand): "+joystickName;
+        printf("%s\n",msg.c_str());
 
         if (model != "") {
             if (!games[model].empty()) {

--- a/src/FPPArcade.h
+++ b/src/FPPArcade.h
@@ -13,7 +13,7 @@ public:
     virtual const std::string &getName() = 0;
     
     virtual void button(const std::string &button) {}
-    virtual void axis(const std::string &axis, int value);
+    virtual void axis(const std::string &axis, int value,const std::string &extraInfo = "");
 
     
     virtual bool isRunning();

--- a/src/FPPArcade.h
+++ b/src/FPPArcade.h
@@ -13,7 +13,7 @@ public:
     virtual const std::string &getName() = 0;
     
     virtual void button(const std::string &button) {}
-    virtual void axis(const std::string &axis, int value,const std::string &extraInfo = "");
+    virtual void axis(const std::string &axis, int value,const std::string &joystickName = "");
 
     
     virtual bool isRunning();

--- a/src/FPPBreakout.cpp
+++ b/src/FPPBreakout.cpp
@@ -226,7 +226,14 @@ public:
             y *= length;
         }
     }
-    void button(const std::string &button) {
+    void button(const std::string &butt) {
+        std::string button = butt;
+        std::string joystickName = "";
+        size_t pos = butt.find('|');
+        if (pos != std::string::npos) {
+            button = butt.substr(0, pos);
+            joystickName = butt.substr(pos+1);
+        }
         if (button == "Left - Pressed") {
             direction = -1;
         } else if (button == "Left - Released") {

--- a/src/FPPPong.cpp
+++ b/src/FPPPong.cpp
@@ -259,6 +259,9 @@ void FPPPong::button(const std::string &button) {
     PixelOverlayModel *m = PixelOverlayManager::INSTANCE.getModel(modelName);
     if (m != nullptr) {
         PongEffect *effect = dynamic_cast<PongEffect*>(m->getRunningEffect());
+        std::string msg = "Plugin log (FPPPong::button): "+button;
+        std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+        log << msg << std::endl;
         if (!effect) {
             if (findOption("overlay", "Overwrite") == "Transparent") {
                 m->setState(PixelOverlayState(PixelOverlayState::PixelState::TransparentRGB));

--- a/src/FPPPong.cpp
+++ b/src/FPPPong.cpp
@@ -176,8 +176,43 @@ public:
         }
     }
     
-    void button(const std::string &button) {
-        if (controls == 2) {
+    void button(const std::string &butt) {
+        std::string button = butt;
+        std::string joystickName = ""
+        size_t pos = butt.find('|');
+        if (pos != std::string::npos) {
+            button = butt.substr(0, pos);
+            joystickName = butt.substr(pos+1);
+        }
+        std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+        auto now = std::chrono::system_clock::now();
+        std::time_t now_c = std::chrono::system_clock::to_time_t(now);
+        log << "[" << std::put_time(std::localtime(&now_c), "%Y-%m-%d %H:%M:%S") << "] ";
+        log << "Control: " << controls << std::endl;
+        if (controls == 4){
+            auto now = std::chrono::system_clock::now();
+            std::time_t now_c = std::chrono::system_clock::to_time_t(now);
+            log << "[" << std::put_time(std::localtime(&now_c), "%Y-%m-%d %H:%M:%S") << "] ";
+            if (joystickName.ends_with("2")){
+                log << "Joystick 2" << button << std::endl;
+                if (button == "Up - Pressed") {
+                    racketP2Speed = -1;
+                } else if (button == "Down - Pressed") {
+                    racketP2Speed = 1;
+                } else if (button == "Down - Released" || button == "Up - Released") {
+                    racketP2Speed = 0;
+                } else 
+            } else {
+                log << "Joystick 1" << button << std::endl;
+                if (button == "Up - Pressed") {
+                    racketP1Speed = -1;
+                } else if (button == "Down - Pressed") {
+                    racketP1Speed = 1;
+                } else if (button == "Down - Released" || button == "Up - Released") {
+                    racketP1Speed = 0;
+                }
+            }
+        } else if (controls == 2) {
             if (button == "Up/Right - Pressed") {
                 racketP2Speed = -1;
             } else if (button == "Down/Right - Pressed") {
@@ -259,9 +294,6 @@ void FPPPong::button(const std::string &button) {
     PixelOverlayModel *m = PixelOverlayManager::INSTANCE.getModel(modelName);
     if (m != nullptr) {
         PongEffect *effect = dynamic_cast<PongEffect*>(m->getRunningEffect());
-        std::string msg = "Plugin log (FPPPong::button): "+button;
-        std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
-        log << msg << std::endl;
         if (!effect) {
             if (findOption("overlay", "Overwrite") == "Transparent") {
                 m->setState(PixelOverlayState(PixelOverlayState::PixelState::TransparentRGB));

--- a/src/FPPPong.cpp
+++ b/src/FPPPong.cpp
@@ -178,7 +178,7 @@ public:
     
     void button(const std::string &butt) {
         std::string button = butt;
-        std::string joystickName = ""
+        std::string joystickName = "";
         size_t pos = butt.find('|');
         if (pos != std::string::npos) {
             button = butt.substr(0, pos);
@@ -194,16 +194,16 @@ public:
             std::time_t now_c = std::chrono::system_clock::to_time_t(now);
             log << "[" << std::put_time(std::localtime(&now_c), "%Y-%m-%d %H:%M:%S") << "] ";
             if (joystickName.ends_with("2")){
-                log << "Joystick 2" << button << std::endl;
+                log << "Joystick 2: " << button << std::endl;
                 if (button == "Up - Pressed") {
                     racketP2Speed = -1;
                 } else if (button == "Down - Pressed") {
                     racketP2Speed = 1;
                 } else if (button == "Down - Released" || button == "Up - Released") {
                     racketP2Speed = 0;
-                } else 
+                }
             } else {
-                log << "Joystick 1" << button << std::endl;
+                log << "Joystick 1: " << button << std::endl;
                 if (button == "Up - Pressed") {
                     racketP1Speed = -1;
                 } else if (button == "Down - Pressed") {

--- a/src/FPPPong.cpp
+++ b/src/FPPPong.cpp
@@ -184,7 +184,7 @@ public:
             button = butt.substr(0, pos);
             joystickName = butt.substr(pos+1);
         }
-        std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
+        std::ofstream log("/home/fpp/media/plugins/fpp-arcade/log", std::ios::app);
         auto now = std::chrono::system_clock::now();
         std::time_t now_c = std::chrono::system_clock::to_time_t(now);
         log << "[" << std::put_time(std::localtime(&now_c), "%Y-%m-%d %H:%M:%S") << "] ";

--- a/src/FPPPong.cpp
+++ b/src/FPPPong.cpp
@@ -184,17 +184,8 @@ public:
             button = butt.substr(0, pos);
             joystickName = butt.substr(pos+1);
         }
-        std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
-        auto now = std::chrono::system_clock::now();
-        std::time_t now_c = std::chrono::system_clock::to_time_t(now);
-        log << "[" << std::put_time(std::localtime(&now_c), "%Y-%m-%d %H:%M:%S") << "] ";
-        log << "Control: " << controls << std::endl;
         if (controls == 4){
-            auto now = std::chrono::system_clock::now();
-            std::time_t now_c = std::chrono::system_clock::to_time_t(now);
-            log << "[" << std::put_time(std::localtime(&now_c), "%Y-%m-%d %H:%M:%S") << "] ";
             if (joystickName.ends_with("2")){
-                log << "Joystick 2: " << button << std::endl;
                 if (button == "Up - Pressed") {
                     racketP2Speed = -1;
                 } else if (button == "Down - Pressed") {
@@ -203,7 +194,6 @@ public:
                     racketP2Speed = 0;
                 }
             } else {
-                log << "Joystick 1: " << button << std::endl;
                 if (button == "Up - Pressed") {
                     racketP1Speed = -1;
                 } else if (button == "Down - Pressed") {

--- a/src/FPPPong.cpp
+++ b/src/FPPPong.cpp
@@ -184,7 +184,7 @@ public:
             button = butt.substr(0, pos);
             joystickName = butt.substr(pos+1);
         }
-        std::ofstream log("/home/fpp/media/plugins/fpp-arcade/log", std::ios::app);
+        std::ofstream log("/home/fpp/media/plugins/fpp-arcade2/log", std::ios::app);
         auto now = std::chrono::system_clock::now();
         std::time_t now_c = std::chrono::system_clock::to_time_t(now);
         log << "[" << std::put_time(std::localtime(&now_c), "%Y-%m-%d %H:%M:%S") << "] ";

--- a/src/FPPSnake.cpp
+++ b/src/FPPSnake.cpp
@@ -165,7 +165,14 @@ public:
     }
     
     
-    void button(const std::string &button) {
+    void button(const std::string &butt) {
+        std::string button = butt;
+        std::string joystickName = "";
+        size_t pos = butt.find('|');
+        if (pos != std::string::npos) {
+            button = butt.substr(0, pos);
+            joystickName = butt.substr(pos+1);
+        }
         if (button == "Left - Pressed") {
             direction = 0;
         } else if (button == "Right - Pressed") {

--- a/src/FPPTetris.cpp
+++ b/src/FPPTetris.cpp
@@ -300,7 +300,14 @@ public:
         return timer;
     }
     
-    void button(const std::string &button) {
+    void button(const std::string &butt) {
+        std::string button = butt;
+        std::string joystickName = "";
+        size_t pos = butt.find('|');
+        if (pos != std::string::npos) {
+            button = butt.substr(0, pos);
+            joystickName = butt.substr(pos+1);
+        }
         if (!GameOn) {
             return;
         }


### PR DESCRIPTION
Updates to allow two players to play Pong with separate controllers and both use the Up/Down controls vs having to use Up/Down and Left/Right.  All other games work as before.  I did change the name of the repo so that it doesn't conflict with the existing fpp-arcade plugin.  If you are willing to accept the updates, we can change that.