### PR TITLE
Add multiplayer support for Pong

### DIFF
--- a/plugin_setup.php
+++ b/plugin_setup.php
@@ -47,6 +47,7 @@ function GetPongOptions() {
     html += "<option value='1'>Up/Down and Left/Right</option>";
     html += "<option value='2'>UpLeft/DownLeft and UpRight/DownRight</option>";
     html += "<option value='3'>Up/Left and Right/Down </option>";
+    html += "<option value='4'>Multi-Player</option>";
     html += "</select>"
     return html;
 }

--- a/src/FPPArcade.cpp
+++ b/src/FPPArcade.cpp
@@ -203,7 +203,7 @@ void FPPArcadeGame::stop() {
     }
 }
 //default behavior will map the axis directions to button presses
-void FPPArcadeGame::axis(const std::string &axis, int value) {
+void FPPArcadeGame::axis(const std::string &axis, int value, const std::string &joystickName) {
     std::string btn = "";
     if (axis == AXIS[2]) { // DOWN->UP
         if (value == 0 && lastValues[0] < 0) {
@@ -243,6 +243,9 @@ void FPPArcadeGame::axis(const std::string &axis, int value) {
         lastValues[1] = value;
     }
     if (btn != "") {
+        if (joystickName != "") {
+            btn += "|" + joystickName;
+        }
         button(btn);
     }
 }
@@ -469,15 +472,16 @@ public:
         const std::string axis = args[0];
         const std::string model = args.size() > 1 ? args[1] : "";
         int value = args.size() > 2 ? std::atoi(args[2].c_str()) : 0;
+        const std::string joystickName = args.size() > 3 ? args[3] : "";
 
         if (model != "") {
             if (!games[model].empty()) {
-                games[model].front()->axis(axis, value);
+                games[model].front()->axis(axis, value, joystickName);
             }
         } else {
             for (auto &a : games) {
                 if (!a.second.empty()) {
-                    a.second.front()->axis(axis, value);
+                    a.second.front()->axis(axis, value, joystickName);
                 }
             }
         }
@@ -719,6 +723,10 @@ public:
                 if (f->second["command"] == "FPP Arcade Axis") {
                     Json::Value val = f->second;
                     val["args"][2] = std::to_string(value);
+                    size_t colonPos = ev.find(':');
+                    if (colonPos != std::string::npos) {
+                        val["args"][3] = ev.substr(0, colonPos);
+                    }
                     CommandManager::INSTANCE.run(val);
                 } else {
                     CommandManager::INSTANCE.run(f->second);

--- a/src/FPPArcade.h
+++ b/src/FPPArcade.h
@@ -13,7 +13,7 @@ public:
     virtual const std::string &getName() = 0;
     
     virtual void button(const std::string &button) {}
-    virtual void axis(const std::string &axis, int value);
+    virtual void axis(const std::string &axis, int value, const std::string &joystickName = "");
 
     
     virtual bool isRunning();

--- a/src/FPPBreakout.cpp
+++ b/src/FPPBreakout.cpp
@@ -226,7 +226,12 @@ public:
             y *= length;
         }
     }
-    void button(const std::string &button) {
+    void button(const std::string &butt) {
+        std::string button = butt;
+        size_t pos = butt.find('|');
+        if (pos != std::string::npos) {
+            button = butt.substr(0, pos);
+        }
         if (button == "Left - Pressed") {
             direction = -1;
         } else if (button == "Left - Released") {

--- a/src/FPPPong.cpp
+++ b/src/FPPPong.cpp
@@ -176,8 +176,25 @@ public:
         }
     }
     
-    void button(const std::string &button) {
-        if (controls == 2) {
+    void button(const std::string &butt) {
+        std::string button = butt;
+        std::string joystickName = "";
+        size_t pos = butt.find('|');
+        if (pos != std::string::npos) {
+            button = butt.substr(0, pos);
+            joystickName = butt.substr(pos + 1);
+        }
+        if (controls == 4) {
+            if (joystickName.ends_with("2")) {
+                if (button == "Up - Pressed") { racketP2Speed = -1; }
+                else if (button == "Down - Pressed") { racketP2Speed = 1; }
+                else if (button == "Down - Released" || button == "Up - Released") { racketP2Speed = 0; }
+            } else {
+                if (button == "Up - Pressed") { racketP1Speed = -1; }
+                else if (button == "Down - Pressed") { racketP1Speed = 1; }
+                else if (button == "Down - Released" || button == "Up - Released") { racketP1Speed = 0; }
+            }
+        } else if (controls == 2) {
             if (button == "Up/Right - Pressed") {
                 racketP2Speed = -1;
             } else if (button == "Down/Right - Pressed") {

--- a/src/FPPSnake.cpp
+++ b/src/FPPSnake.cpp
@@ -165,7 +165,12 @@ public:
     }
     
     
-    void button(const std::string &button) {
+    void button(const std::string &butt) {
+        std::string button = butt;
+        size_t pos = butt.find('|');
+        if (pos != std::string::npos) {
+            button = butt.substr(0, pos);
+        }
         if (button == "Left - Pressed") {
             direction = 0;
         } else if (button == "Right - Pressed") {

--- a/src/FPPTetris.cpp
+++ b/src/FPPTetris.cpp
@@ -300,7 +300,12 @@ public:
         return timer;
     }
     
-    void button(const std::string &button) {
+    void button(const std::string &butt) {
+        std::string button = butt;
+        size_t pos = butt.find('|');
+        if (pos != std::string::npos) {
+            button = butt.substr(0, pos);
+        }
         if (!GameOn) {
             return;
         }


### PR DESCRIPTION
## Summary

- Threads joystick controller name through the axis command pipeline so two separate USB controllers can each use Up/Down independently for Pong
- Adds a "Multi-Player" control mode (controls == 4) that routes input to P1 or P2 based on the controller name
- Other games (Tetris, Snake, Breakout) strip the controller name suffix and are unaffected

Squashed and rebased onto the latest FPP10 plugin code as requested in #8.

## Changes

- **FPPArcade.h** — `axis()` gains an optional `joystickName` parameter
- **FPPArcade.cpp** — extracts controller name from joystick events and passes it through `runAxisCommand()` → `axis()` → `button()`
- **FPPPong.cpp** — new `controls == 4` branch differentiates controllers by name suffix
- **FPPBreakout/Snake/Tetris.cpp** — strip `|joystickName` suffix before processing buttons
- **plugin_setup.php** — adds "Multi-Player" option to Pong controls dropdown

Supersedes #8.